### PR TITLE
Add meta info for galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,13 @@
+galaxy_info:
+  author: ome-devel@lists.openmicroscopy.org.uk
+  description: Setup GlusterFS and Heketi for dynamic volume provisioning with kubernetes
+  company: Open Microscopy Environment
+  license: BSD
+  min_ansible_version: 2.4
+  platforms:
+  - name: EL
+    versions:
+    - 7
+  galaxy_tags: []
+
+dependencies: []


### PR DESCRIPTION
Needed for `ansible-galaxy install`. I forgot to add the meta directory before tagging this role.

Suggested tag: `0.1.1`